### PR TITLE
change bucket name to be dynamic

### DIFF
--- a/src/variables/Variable.php
+++ b/src/variables/Variable.php
@@ -54,7 +54,7 @@ class Variable
         }
 
         $json = [
-            "bucket" => "craft-image-processor-test-2",
+            "bucket" => $image->getVolume()->bucket,
             "key" => $image['filename'],
             "edits" => [
                 "resize" => [


### PR DESCRIPTION
Bucket name was previously hard-coded. It now references the bucket name of the image's volume.