### PR TITLE
check for subfolders

### DIFF
--- a/src/variables/Variable.php
+++ b/src/variables/Variable.php
@@ -55,7 +55,7 @@ class Variable
 
         $json = [
             "bucket" => $image->getVolume()->bucket,
-            "key" => $image['filename'],
+            "key" => $image->getVolume()->subfolder ? $image->getVolume()->subfolder . "/" . $image['filename'] : $image['filename'],
             "edits" => [
                 "resize" => [
                     "width" => (isset($edits['width']) ? $edits['width'] : 800),


### PR DESCRIPTION
The image handler expects any subfolders to be prepended to the key. This checks if there are any subfolders that need to be included. 