### PR TITLE
Add plugin setting for SIH distribution URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ After setting up the S3 volume follow these instructions to install the plugin.
 
 4. Add `Toggle aws image processor` to your s3 volume field layout.
 
+## Plugin Settings
+
+` Serverless Distribution URL ` (optional)
+
+This field is for the Serverless Image Handler CloudFront Distribution URL, which frees up your asset volume distribution URL to be a regular CloudFront distribution URL. This means that any asset in the volume that does not pass through this plugin (rich text fields, certain SEO plugins, etc) will be served normally. 
+
 ## Usage
 
 In your twig template you can use:

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "dutchheight/aws-serverless-image-handler",
     "description": "Craft CMS plugin to generate resource URL",
     "type": "craft-plugin",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "extra": {
         "name": "aws-serverless-image-handler",
         "handle": "aws-serverless-image-handler",
-        "hasCpSettings": false,
+        "hasCpSettings": true,
         "hasCpSection": false,
         "changelogUrl": "???",
         "class": "dutchheight\\awsserverlessimagehandler\\Awsserverlessimagehandler"

--- a/src/Awsserverlessimagehandler.php
+++ b/src/Awsserverlessimagehandler.php
@@ -23,7 +23,7 @@ use craft\events\RegisterComponentTypesEvent;
 
 use craft\web\twig\variables\CraftVariable;
 
-
+use dutchheight\awsserverlessimagehandler\models\Settings;
 use dutchheight\awsserverlessimagehandler\fields\ImageProperties;
 use dutchheight\awsserverlessimagehandler\variables\Variable;
 use dutchheight\awsserverlessimagehandler\services\HelperService;
@@ -54,6 +54,11 @@ class Awsserverlessimagehandler extends Plugin
      */
     public $schemaVersion = '1.0.0';
 
+    /**
+     * @var bool
+     */
+    public $hasCpSettings = true;
+
     // Public Methods
     // =========================================================================
 
@@ -82,7 +87,7 @@ class Awsserverlessimagehandler extends Plugin
 
     // Protected Methods
     // =========================================================================
-    
+
     protected function registerComponents() {
         $this->setComponents([
             'helpers' => HelperService::class
@@ -112,6 +117,21 @@ class Awsserverlessimagehandler extends Plugin
                 $variable = $event->sender;
                 $variable->set('awsserverlessimagehandler', Variable::class);
             }
+        );
+    }
+
+    protected function createSettingsModel()
+    {
+        return new Settings();
+    }
+
+    protected function settingsHtml()
+    {
+        return Craft::$app->view->renderTemplate(
+            'aws-serverless-image-handler/settings',
+            [
+            'settings' => $this->getSettings()
+            ]
         );
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace dutchheight\awsserverlessimagehandler\models;
+
+use dutchheight\awsserverlessimagehandler\Awsserverlessimagehandler;
+
+use Craft;
+use craft\base\Model;
+
+class Settings extends Model
+{
+  public $serverlessDistributionURL = '';
+
+  public function rules()
+  {
+    return [
+      ['serverlessDistributionURL', 'required'],
+      ['serverlessDistributionURL', 'string'],
+    ];
+  }
+
+  public function getSecretKey(): string
+  {
+    return Craft::parseEnv($this->serverlessDistributionURL);
+  }
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -14,7 +14,6 @@ class Settings extends Model
   public function rules()
   {
     return [
-      ['serverlessDistributionURL', 'required'],
       ['serverlessDistributionURL', 'string'],
     ];
   }

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -5,7 +5,7 @@
     instructions: 'Enter your AWS Serverless Image Handler CloudFront Distribution URL here.',
     name: 'serverlessDistributionURL', 
     id: 'serverlessDistributionURL', 
-    required: true,
+    required: false,
     value: settings.serverlessDistributionURL,
     suggestEnvVars: true,
     suggestAliases: true,

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -1,0 +1,12 @@
+{% import "_includes/forms" as forms %}
+
+{{ forms.autosuggestField({
+    label: 'Serverless Distribution URL',
+    instructions: 'Enter your AWS Serverless Image Handler CloudFront Distribution URL here.',
+    name: 'serverlessDistributionURL', 
+    id: 'serverlessDistributionURL', 
+    required: true,
+    value: settings.serverlessDistributionURL,
+    suggestEnvVars: true,
+    suggestAliases: true,
+}) }}

--- a/src/variables/Variable.php
+++ b/src/variables/Variable.php
@@ -54,7 +54,9 @@ class Variable
             return $image->url;
         }
 
-        $distributionUrl = Awsserverlessimagehandler::$plugin->settings->serverlessDistributionURL;
+        $distributionSettingUrl = Craft::parseEnv(Awsserverlessimagehandler::$plugin->settings->serverlessDistributionURL);
+        $volumeUrl = (Craft::parseEnv($image->volume->url) ?: $image->volume->url);
+        $distributionUrl = $distributionSettingUrl ?: $volumeUrl;
         $volumeSubfolder = (Craft::parseEnv($image->getVolume()->subfolder) ?: $image->getVolume()->subfolder);
 
         $json = [
@@ -98,6 +100,6 @@ class Variable
             $json["edits"]["webp"] = [];
         }
 
-        echo (Craft::parseEnv($distributionUrl) ?: $distributionUrl) . base64_encode(json_encode($json));
+        echo $distributionUrl . base64_encode(json_encode($json));
     }
 }

--- a/src/variables/Variable.php
+++ b/src/variables/Variable.php
@@ -54,6 +54,7 @@ class Variable
             return $image->url;
         }
 
+        $distributionUrl = Awsserverlessimagehandler::$plugin->settings->serverlessDistributionURL;
         $volumeSubfolder = (Craft::parseEnv($image->getVolume()->subfolder) ?: $image->getVolume()->subfolder);
 
         $json = [
@@ -97,6 +98,6 @@ class Variable
             $json["edits"]["webp"] = [];
         }
 
-        echo (Craft::parseEnv($image->volume->url) ?: $image->volume->url) . base64_encode(json_encode($json));
+        echo (Craft::parseEnv($distributionUrl) ?: $distributionUrl) . base64_encode(json_encode($json));
     }
 }

--- a/src/variables/Variable.php
+++ b/src/variables/Variable.php
@@ -55,9 +55,9 @@ class Variable
         }
 
         $distributionSettingUrl = Craft::parseEnv(Awsserverlessimagehandler::$plugin->settings->serverlessDistributionURL);
-        $volumeUrl = (Craft::parseEnv($image->volume->url) ?: $image->volume->url);
+        $volumeUrl = Craft::parseEnv($image->volume->url);
         $distributionUrl = $distributionSettingUrl ?: $volumeUrl;
-        $volumeSubfolder = (Craft::parseEnv($image->getVolume()->subfolder) ?: $image->getVolume()->subfolder);
+        $volumeSubfolder = Craft::parseEnv($image->getVolume()->subfolder);
 
         $json = [
             "bucket" => $image->getVolume()->bucket,

--- a/src/variables/Variable.php
+++ b/src/variables/Variable.php
@@ -61,7 +61,7 @@ class Variable
 
         $json = [
             "bucket" => $image->getVolume()->bucket,
-            "key" => $volumeSubfolder ? $volumeSubfolder . "/" . $image['filename'] : $image['filename'],
+            "key" => $volumeSubfolder ? $volumeSubfolder . "/" . $image->getPath() : $image->getPath(),
             "edits" => [
                 "resize" => [
                     "fit" => (isset($edits['fit']) ? $edits['fit'] : "cover"),


### PR DESCRIPTION
This adds a plugin setting to the control panel that enables users to define the Serverless Image Handler distribution URL separate from the asset volume distribution URL. This means that any asset in the volume that does not pass through this plugin (rich text fields, certain SEO plugins, etc) will be served normally. 